### PR TITLE
Minor fixes on compile() and tracking_allocator_proc()

### DIFF
--- a/modules/Rematch/allocator.jai
+++ b/modules/Rematch/allocator.jai
@@ -23,10 +23,14 @@ tracking_allocator_proc :: (mode: Allocator_Mode, size: s64, old_size: s64, old_
     ta.high_water_mark = max(ta.high_water_mark, ta.current_allocated);
 
     real_old_memory := old_memory;
-    if real_old_memory then real_old_memory -= size_of(int);
+    real_old_size := old_size;
+    if real_old_memory {
+        real_old_memory -= size_of(int);
+        real_old_size += size_of(int);
+    }
 
     // Store size so we can adjust on free
-    data := ta.allocator.proc(mode, size + size_of(int), old_size + size_of(int), real_old_memory, ta.allocator.data);
+    data := ta.allocator.proc(mode, size + size_of(int), real_old_size, real_old_memory, ta.allocator.data);
     if data then data.(*int).* = size;
     return data + size_of(int);
 }

--- a/modules/Rematch/compile.jai
+++ b/modules/Rematch/compile.jai
@@ -340,7 +340,9 @@ compile :: (pattern: string, flags := Flags.NONE) -> Regex, bool {
                 } else if p.data[0] == #char "}" {
                     max_str = min_str;
                 }
-
+                if !p.count {
+                    return regex, false;
+                }
                 assert(p.data[0] == #char "}");
 
                 min := to_integer(min_str);
@@ -604,13 +606,19 @@ parse_escape :: (p: *string) -> int, bool {
 
         case #char "x";
             // \xFF
+            if p.count < 3 {
+                return 0, false;
+            }
             advance(p);
             hex_str := p.*;
             hex_str.count = 2;
             advance(p, 2);
             result, success := string_to_int(hex_str, base=16);
             return result, success;
-            case #char "u";
+        case #char "u";
+            if p.count < 3 {
+                return 0, false;
+            }
             advance(p);
             hex_str := p.*;
             hex_str.count = 0;
@@ -632,6 +640,9 @@ parse_escape :: (p: *string) -> int, bool {
                 advance(p);
             } else {
                 // \uHHHH
+                if p.count < 4 {
+                    return 0, false;
+                }
                 advance(p, 4);
                 hex_str.count = 4;
             }

--- a/modules/Rematch/compile.jai
+++ b/modules/Rematch/compile.jai
@@ -190,8 +190,14 @@ compile :: (pattern: string, flags := Flags.NONE) -> Regex, bool {
                 group.flags = peek(group_stack).flags;
 
                 advance(p);
+                if !p.count {
+                    return regex, false;
+                }
                 if p.data[0] == #char "?" {
                     advance(p);
+                    if !p.count {
+                        return regex, false;
+                    }
 
                     if p.data[0] == {
                         case #char ":";
@@ -212,6 +218,9 @@ compile :: (pattern: string, flags := Flags.NONE) -> Regex, bool {
 
                         case #char "<";
                             advance(p);
+                            if !p.count {
+                                return regex, false;
+                            }
                             if p.data[0] == {
                                 case #char "!";
                                     // Negative lookbehind (?<!Foo)
@@ -243,20 +252,23 @@ compile :: (pattern: string, flags := Flags.NONE) -> Regex, bool {
                             flags_to_enable := p.*;
                             flags_to_enable.count = 0;
 
-                            while true {
+                            while p.count {
                                 if p.data[0] == #char "-" || p.data[0] == #char ":" then break;
                                 flags_to_enable.count += 1;
                                 advance(p);
                             }
 
                             flags_to_disable: string;
+                            if !p.count {
+                                return regex, false;
+                            }
                             if p.data[0] == #char "-" {
                                 advance(p);
 
                                 flags_to_disable = p.*;
                                 flags_to_disable.count = 0;
 
-                                while p.data[0] != #char ":" {
+                                while p.count && p.data[0] != #char ":" {
                                     flags_to_disable.count += 1;
                                     advance(p);
                                 }
@@ -307,6 +319,9 @@ compile :: (pattern: string, flags := Flags.NONE) -> Regex, bool {
 
                 min_str := p.*;
                 min_str.count = 0;
+                if !p.count {
+                    return regex, false;
+                }
                 if p.data[0] != #char "," {
                     while p.count > 0 {
                         advance(p);
@@ -343,6 +358,9 @@ compile :: (pattern: string, flags := Flags.NONE) -> Regex, bool {
                 advance(p);
 
                 negated := false;
+                if !p.count {
+                    return regex, false;
+                }
                 if p.data[0] == #char "^" {
                     negated = true;
                     advance(p);
@@ -351,13 +369,16 @@ compile :: (pattern: string, flags := Flags.NONE) -> Regex, bool {
                 chars: [..] Char_Class;
                 chars.allocator = temp;
 
-                while p.data[0] != #char "]" {
+                while p.count && p.data[0] != #char "]" {
                     start, start_size := get_codepoint(p);
 
                     if start == #char "\\" {
                         start=, success := parse_escape(p);
                         if !success {
                             advance(p);
+                            if !p.count {
+                                return regex, false;
+                            }
                             if p.data[0] == {
                                 case #char "W";
                                     array_add(*chars, ..NEGATED_WORD_CHAR_CLASS);
@@ -388,7 +409,7 @@ compile :: (pattern: string, flags := Flags.NONE) -> Regex, bool {
 
 
                     end := start;
-                    if p.data[0] == #char "-" && p.data[1] != #char "]" {
+                    if p.count > 1 && p.data[0] == #char "-" && p.data[1] != #char "]" {
                         advance(p);
 
                         end=, end_size := get_codepoint(p);
@@ -403,7 +424,9 @@ compile :: (pattern: string, flags := Flags.NONE) -> Regex, bool {
                 }
 
                 add_char_class(negated, ..chars);
-
+                if !p.count {
+                    return regex, false;
+                }
                 assert(p.data[0] == #char "]");
                 char = #char "]";
 
@@ -466,14 +489,20 @@ compile :: (pattern: string, flags := Flags.NONE) -> Regex, bool {
                         // Named backreference
                         advance(p);
                         advance(p);
+                        if !p.count {
+                            return regex, false;
+                        }
                         if p.data[0] != #char "<" then return regex, false;
                         advance(p);
                         name := p.*;
                         name.count = 0;
 
-                        while p.data[0] != #char ">" {
+                        while p.count && p.data[0] != #char ">" {
                             advance(p);
                             name.count += 1;
+                        }
+                        if !p.count {
+                            return regex, false;
                         }
                         advance(p);
                         add_backreference(name);


### PR DESCRIPTION
Hi, thanks for this awesome package!

This PR adds two minor robustness fixes:

1. Add some explicit bound checks and early returns into `compile`.

    Previously, malformed input like `a[` would trigger an array bound check error, crashing the program. This PR adds a bunch of explicit checks to the procedure to make it more robust against such bad inputs.

2. Fix the handling of `old_size` within `tracking_allocator_proc`.

    Some procedures like `array_add` would trigger an `RESIZE` allocation on null pointers, in which case the allocator_proc would be invoked with `old_memory == null` and `old_size == 0`. Allocators usually can handle this correctly, but if we forward them a modified size, some allocators like `flat_pool_allocator_proc` in the built-in modules would fail. This PR patches it by only send in the modified size when `old_memory != null`.